### PR TITLE
Add iota and iota-description lang

### DIFF
--- a/common/src/main/resources/assets/hexstruction/lang/en_us.flatten.json5
+++ b/common/src/main/resources/assets/hexstruction/lang/en_us.flatten.json5
@@ -1,5 +1,9 @@
 {
   hexcasting: {
+    iota: {
+      "hexstruction:structure": "Structure",
+      "hexstruction:structure.desc": "a structure iota"
+    },
     action: {
       "hexstruction:": {
         save_structure: "Devour Structure",


### PR DESCRIPTION
Going forward, addons should implement these lang keys for their iotas, for use in MishapInvalidIota.